### PR TITLE
Setup github action with yarn lint step

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,10 @@
+name: CI Checks
+on: push
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: |
+          yarn install --frozen-lockfile
+          yarn lint


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow named `CI Checks` in the `.github/workflows/main.yaml` file. This workflow is triggered on every push to the repository and it runs a linting job on the latest Ubuntu environment. The job checks out the code and then installs the project dependencies using `yarn install --frozen-lockfile`, followed by running the linter with `yarn lint`.